### PR TITLE
update container get after autowire change

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -181,3 +181,10 @@ jobs:
           ./scripts/rector
       - name: Check nothing has changed
         run: git diff --exit-code
+  
+  test-command-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          ./scripts/run-command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [PR-18](https://github.com/itk-dev/azure-ad-delta-sync-drupal/pull/18)
   * Update `container->get` after autowire change
-  * Change logging: https://drupalize.me/blog/how-log-messages-drupal-8
+  * Change logging: <https://drupalize.me/blog/how-log-messages-drupal-8>
   * Remove unused `drupal_psr6_cache`
   * Add run-command script to test if command runs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * [PR-18](https://github.com/itk-dev/azure-ad-delta-sync-drupal/pull/18)
-  update container get after autowire change
+  * Update `container->get` after autowire change
+  * Change logging: https://drupalize.me/blog/how-log-messages-drupal-8
+  * Remove unused `drupal_psr6_cache`
+  * Add run-command script to test if command runs
 
 ## [2.0.1] - 2025-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-18](https://github.com/itk-dev/azure-ad-delta-sync-drupal/pull/18)
+  update container get after autowire change
+
 ## [2.0.1] - 2025-03-04
 
 * [PR-16](https://github.com/itk-dev/azure-ad-delta-sync-drupal/pull/16)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ phpstan is used to perform static analysis of the code. Run the following script
 ./scripts/code-analysis
 ```
 
+### Rector
+
+Automatic code upgrades
+
+`./scripts/rector`
+
 ### GitHub Actions
 
 We use [GitHub Actions](https://github.com/features/actions) to check coding standards, perform code analysis and run

--- a/README.md
+++ b/README.md
@@ -21,10 +21,8 @@ $config['azure_ad_delta_sync.settings']['azure']['security_key'] = '…';
 $config['azure_ad_delta_sync.settings']['azure']['client_secret'] = '…';
 ```
 
-Furthermore, you may want to install the [Config
-Ignore](https://www.drupal.org/project/config_ignore) module and ignore the
-`azure_ad_delta_sync.settings` config if committing config to a version control
-system.
+Furthermore, you may want to install the [Config Ignore](https://www.drupal.org/project/config_ignore) module and ignore
+the `azure_ad_delta_sync.settings` config if committing config to a version control system.
 
 ## Usage
 
@@ -39,13 +37,10 @@ Run `vendor/bin/drush azure_ad_delta_sync:run --help` for details on the command
 ## Development
 
 For development you need a full Drupal project. See
-[itk-dev/azure-ad-delta-sync-drupal-test](https://github.com/itk-dev/azure-ad-delta-sync-drupal-test)
-for an example.
+[itk-dev/azure-ad-delta-sync-drupal-test](https://github.com/itk-dev/azure-ad-delta-sync-drupal-test) for an example.
 
-We use lazy services, `azure_ad_delta_sync.user_manager`
-(`Drupal\azure_ad_delta_sync\UserManager`) and `azure_ad_delta_sync.controller`
-(`Drupal\azure_ad_delta_sync\Controller`), which require generating proxy
-classes (cf. <https://www.webomelette.com/lazy-loaded-services-drupal-8>).
+We use lazy services, `aDrupal\azure_ad_delta_sync\UserManager` and `Drupal\azure_ad_delta_sync\Controller`, which
+require generating proxy classes (cf. <https://www.webomelette.com/lazy-loaded-services-drupal-8>).
 
 Run the following command to update the proxy classes:
 
@@ -55,8 +50,7 @@ Run the following command to update the proxy classes:
 
 ## Automated tests
 
-Requires a full Drupal installation with the `azure_ad_delta_sync_drupal` module in the
-`web/modules/contrib` folder.
+Requires a full Drupal installation with the `azure_ad_delta_sync_drupal` module in the `web/modules/contrib` folder.
 
 ```sh
 (cd «DRUPAL_ROOT»/web; ./vendor/bin/phpunit modules/contrib/azure_ad_delta_sync_drupal/tests/src/Functional)
@@ -64,8 +58,7 @@ Requires a full Drupal installation with the `azure_ad_delta_sync_drupal` module
 
 ### Coding standards
 
-The code follows the [Drupal Coding
-Standards](https://www.drupal.org/docs/develop/standards) (cf.
+The code follows the [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards) (cf.
 [`phpcs.xml.dist`](phpcs.xml.dist)) and can be checked by running
 
 ```sh
@@ -98,12 +91,10 @@ phpstan is used to perform static analysis of the code. Run the following script
 
 ### GitHub Actions
 
-We use [GitHub Actions](https://github.com/features/actions) to check coding
-standards, perform code analysis and run automated tests whenever a pull request
-is made (cf. [`.github/workflows/pr.yaml`](.github/workflows/pr.yaml)).
+We use [GitHub Actions](https://github.com/features/actions) to check coding standards, perform code analysis and run
+automated tests whenever a pull request is made (cf. [`.github/workflows/pr.yaml`](.github/workflows/pr.yaml)).
 
-Before making a pull request you can run the GitHub Actions locally to check for
-any problems:
+Before making a pull request you can run the GitHub Actions locally to check for any problems:
 
 [Install `act`](https://github.com/nektos/act#installation) and run
 

--- a/azure_ad_delta_sync.services.yml
+++ b/azure_ad_delta_sync.services.yml
@@ -1,4 +1,7 @@
 services:
+  _defaults: 
+    autowire: true
+
   logger.channel.azure_ad_delta_sync:
     parent: logger.channel_base
     arguments:
@@ -6,16 +9,12 @@ services:
 
   Drupal\azure_ad_delta_sync\Controller:
     lazy: true
-    autowire: true
 
   Drupal\azure_ad_delta_sync\UserManager:
     lazy: true
-    autowire: true
 
   Drupal\azure_ad_delta_sync\Helpers\ConfigHelper:
-    autowire: true
 
   Drupal\azure_ad_delta_sync\Commands\Commands:
-    autowire: true
     tags:
       - { name: drush.command }

--- a/scripts/run-command
+++ b/scripts/run-command
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -o errexit -o errtrace -o noclobber -o nounset -o pipefail
+IFS=$'\n\t'
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$script_dir"
+
+execute() {
+    drush azure_ad_delta_sync:run --test-command-runs
+}
+
+source "$script_dir/base"

--- a/scripts/run-command
+++ b/scripts/run-command
@@ -6,7 +6,7 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$script_dir"
 
 execute() {
-    drush azure_ad_delta_sync:run --test-command-runs
+    drush azure_ad_delta_sync:run --help
 }
 
 source "$script_dir/base"

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -11,7 +11,8 @@ use Drush\Exceptions\CommandFailedException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drush\Commands\AutowireTrait;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-
+use Drupal\azure_ad_delta_sync\UserManager;
+use Drupal\azure_ad_delta_sync\Controller;
 /**
  * Drush commands.
  */
@@ -23,9 +24,9 @@ final class Commands extends DrushCommands {
    * Commands constructor.
    */
   public function __construct(
-    #[Autowire(service: \Drupal\azure_ad_delta_sync\Controller::class)]
+    #[Autowire(service: Controller::class)]
     private readonly ControllerInterface $controller,
-    #[Autowire(service: \Drupal\azure_ad_delta_sync\UserManager::class)]
+    #[Autowire(service: UserManager::class)]
     private readonly UserManagerInterface $userManager,
   ) {
   }
@@ -44,16 +45,10 @@ final class Commands extends DrushCommands {
     array $options = [
       'dry-run' => NULL,
       'force' => NULL,
-      'test-command-runs' => NULL,
     ],
   ): void {
     $dryRun = $options['dry-run'];
     $force = $options['force'];
-    $testCommandRuns = $options['test-command-runs'];
-
-    if ($testCommandRuns) {
-      return;
-    }
 
     if (!$dryRun && !$force) {
       throw new CommandFailedException('Please specify either --dry-run or --force option.');

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -10,6 +10,8 @@ use Drush\Commands\DrushCommands;
 use Drush\Exceptions\CommandFailedException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drush\Commands\AutowireTrait;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
 /**
  * Drush commands.
  */
@@ -21,11 +23,12 @@ final class Commands extends DrushCommands {
    * Commands constructor.
    */
   public function __construct(
+    #[Autowire(service: 'Drupal\azure_ad_delta_sync\Controller')]
     private readonly ControllerInterface $controller,
+    #[Autowire(service: 'Drupal\azure_ad_delta_sync\UserManager')]
     private readonly UserManagerInterface $userManager,
   ) {
   }
-
 
   /**
    * Run.
@@ -41,10 +44,16 @@ final class Commands extends DrushCommands {
     array $options = [
       'dry-run' => NULL,
       'force' => NULL,
+      'test-command-runs' => NULL,
     ],
   ): void {
     $dryRun = $options['dry-run'];
     $force = $options['force'];
+    $testCommandRuns = $options['test-command-runs'];
+
+    if ($testCommandRuns) {
+      return;
+    }
 
     if (!$dryRun && !$force) {
       throw new CommandFailedException('Please specify either --dry-run or --force option.');
@@ -52,7 +61,7 @@ final class Commands extends DrushCommands {
 
     $this->userManager->setOptions([
       'dry-run' => $dryRun,
-      'debug' => $this->output->isDebug(),
+      'debug' => $this->output()->isDebug(),
     ]);
 
     if ($dryRun) {

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -13,6 +13,7 @@ use Drush\Commands\AutowireTrait;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Drupal\azure_ad_delta_sync\UserManager;
 use Drupal\azure_ad_delta_sync\Controller;
+
 /**
  * Drush commands.
  */

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -9,12 +9,13 @@ use Drupal\azure_ad_delta_sync\UserManagerInterface;
 use Drush\Commands\DrushCommands;
 use Drush\Exceptions\CommandFailedException;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
+use Drush\Commands\AutowireTrait;
 /**
  * Drush commands.
  */
 final class Commands extends DrushCommands {
+
+  use AutowireTrait;
 
   /**
    * Commands constructor.
@@ -25,15 +26,6 @@ final class Commands extends DrushCommands {
   ) {
   }
 
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container): self {
-    return new static(
-      $container->get('Drupal\azure_ad_delta_sync\Controller'),
-      $container->get('Drupal\azure_ad_delta_sync\UserManager'),
-    );
-  }
 
   /**
    * Run.

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -25,7 +25,7 @@ final class Commands extends DrushCommands {
   public function __construct(
     #[Autowire(service: \Drupal\azure_ad_delta_sync\Controller::class)]
     private readonly ControllerInterface $controller,
-    #[Autowire(service: \Drupal\azure_ad_delta_sync\UserManager::class)]
+    // #[Autowire(service: \Drupal\azure_ad_delta_sync\UserManager::class)]
     private readonly UserManagerInterface $userManager,
   ) {
   }

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -25,7 +25,7 @@ final class Commands extends DrushCommands {
   public function __construct(
     #[Autowire(service: \Drupal\azure_ad_delta_sync\Controller::class)]
     private readonly ControllerInterface $controller,
-    // #[Autowire(service: \Drupal\azure_ad_delta_sync\UserManager::class)]
+    #[Autowire(service: \Drupal\azure_ad_delta_sync\UserManager::class)]
     private readonly UserManagerInterface $userManager,
   ) {
   }

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -57,6 +57,7 @@ final class Commands extends DrushCommands {
 
     $this->userManager->setOptions([
       'dry-run' => $dryRun,
+      // Shows list of users that are picked for deletion.
       'debug' => $this->output()->isDebug(),
     ]);
 

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -23,9 +23,9 @@ final class Commands extends DrushCommands {
    * Commands constructor.
    */
   public function __construct(
-    #[Autowire(service: 'Drupal\azure_ad_delta_sync\Controller')]
+    #[Autowire(service: \Drupal\azure_ad_delta_sync\Controller::class)]
     private readonly ControllerInterface $controller,
-    #[Autowire(service: 'Drupal\azure_ad_delta_sync\UserManager')]
+    #[Autowire(service: \Drupal\azure_ad_delta_sync\UserManager::class)]
     private readonly UserManagerInterface $userManager,
   ) {
   }

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -30,8 +30,8 @@ final class Commands extends DrushCommands {
    */
   public static function create(ContainerInterface $container): self {
     return new static(
-      $container->get('azure_ad_delta_sync.controller'),
-      $container->get('azure_ad_delta_sync.user_manager'),
+      $container->get('Drupal\azure_ad_delta_sync\Controller'),
+      $container->get('Drupal\azure_ad_delta_sync\UserManager'),
     );
   }
 

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -64,8 +64,8 @@ final class SettingsForm extends ConfigFormBase {
     return new static(
       $container->get('config.factory'),
       $container->get('entity_type.manager'),
-      $container->get('azure_ad_delta_sync.user_manager'),
-      $container->get('azure_ad_delta_sync.config_helper'),
+      $container->get('Drupal\azure_ad_delta_sync\UserManager'),
+      $container->get('Drupal\azure_ad_delta_sync\Helpers\ConfigHelper'),
     );
   }
 

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -7,15 +7,16 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drush\Commands\AutowireTrait;
 use Drupal\azure_ad_delta_sync\Helpers\ConfigHelper;
 
 /**
  * Settings form.
  */
 final class SettingsForm extends ConfigFormBase {
+  use AutowireTrait;
+  
   public const string SETTINGS = 'azure_ad_delta_sync.settings';
-
   /**
    * The user storage.
    *
@@ -54,19 +55,6 @@ final class SettingsForm extends ConfigFormBase {
     parent::__construct($configFactory);
     $this->userStorage = $entityTypeManager->getStorage('user');
     $this->roleStorage = $entityTypeManager->getStorage('user_role');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  #[\Override]
-  public static function create(ContainerInterface $container): static {
-    return new static(
-      $container->get('config.factory'),
-      $container->get('entity_type.manager'),
-      $container->get('Drupal\azure_ad_delta_sync\UserManager'),
-      $container->get('Drupal\azure_ad_delta_sync\Helpers\ConfigHelper'),
-    );
   }
 
   /**

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  */
 final class SettingsForm extends ConfigFormBase {
   use AutowireTrait;
-  
+
   public const string SETTINGS = 'azure_ad_delta_sync.settings';
   /**
    * The user storage.
@@ -50,9 +50,9 @@ final class SettingsForm extends ConfigFormBase {
   public function __construct(
     ConfigFactoryInterface $configFactory,
     EntityTypeManagerInterface $entityTypeManager,
-    #[Autowire(service: 'Drupal\azure_ad_delta_sync\UserManager')]
+    #[Autowire(service: \Drupal\azure_ad_delta_sync\UserManager::class)]
     private readonly UserManagerInterface $userManager,
-    #[Autowire(service: 'Drupal\azure_ad_delta_sync\Helpers\ConfigHelper')]
+    #[Autowire(service: \Drupal\azure_ad_delta_sync\Helpers\ConfigHelper::class)]
     private readonly ConfigHelper $configHelper,
   ) {
     parent::__construct($configFactory);

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -9,6 +9,7 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drush\Commands\AutowireTrait;
 use Drupal\azure_ad_delta_sync\Helpers\ConfigHelper;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Settings form.
@@ -49,7 +50,9 @@ final class SettingsForm extends ConfigFormBase {
   public function __construct(
     ConfigFactoryInterface $configFactory,
     EntityTypeManagerInterface $entityTypeManager,
+    #[Autowire(service: 'Drupal\azure_ad_delta_sync\UserManager')]
     private readonly UserManagerInterface $userManager,
+    #[Autowire(service: 'Drupal\azure_ad_delta_sync\Helpers\ConfigHelper')]
     private readonly ConfigHelper $configHelper,
   ) {
     parent::__construct($configFactory);

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -10,6 +10,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drush\Commands\AutowireTrait;
 use Drupal\azure_ad_delta_sync\Helpers\ConfigHelper;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Drupal\azure_ad_delta_sync\UserManager;
 
 /**
  * Settings form.
@@ -50,9 +51,9 @@ final class SettingsForm extends ConfigFormBase {
   public function __construct(
     ConfigFactoryInterface $configFactory,
     EntityTypeManagerInterface $entityTypeManager,
-    #[Autowire(service: \Drupal\azure_ad_delta_sync\UserManager::class)]
+    #[Autowire(service: UserManager::class)]
     private readonly UserManagerInterface $userManager,
-    #[Autowire(service: \Drupal\azure_ad_delta_sync\Helpers\ConfigHelper::class)]
+    #[Autowire(service: ConfigHelper::class)]
     private readonly ConfigHelper $configHelper,
   ) {
     parent::__construct($configFactory);

--- a/src/Helpers/ConfigHelper.php
+++ b/src/Helpers/ConfigHelper.php
@@ -109,7 +109,7 @@ class ConfigHelper {
   /**
    * Get configuration.
    */
-  public function getConfiguration(string $configName): array|string {
+  public function getConfiguration(string $configName): array|string|null {
     return $this->moduleConfig->get($configName);
   }
 

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -150,7 +150,7 @@ class UserManager implements UserManagerInterface {
     $userIdField = $this->configHelper->getConfiguration('drupal.user_id_field');
 
     $this->logger->info(
-      'Retaining %count users',
+      'Retaining %count user(s)',
            [
              '%count' => count($users),
            ]

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -130,11 +130,13 @@ class UserManager implements UserManagerInterface {
   public function collectUsersForDeletionList(): void {
     $managedUserIds = $this->loadManagedUserIds();
     $this->userIds = $managedUserIds;
-    $this->logger->info($this->formatPlural(
-      count($this->userIds),
-      '1 user marked for deletion.',
-      '@count users marked for deletion.'
-    ));
+
+    $this->logger->info(
+      '%count user(s) marked for deletion.',
+           [
+             '%count' => count($this->userIds),
+           ]
+    );
   }
 
   /**
@@ -147,11 +149,13 @@ class UserManager implements UserManagerInterface {
     $userIdClaim = $this->configHelper->getConfiguration('azure.user_id_claim');
     $userIdField = $this->configHelper->getConfiguration('drupal.user_id_field');
 
-    $this->logger->info($this->formatPlural(
-      count($users),
-      'Retaining one user.',
-      'Retaining @count users.'
-    ));
+    $this->logger->info(
+      'Retaining %count users',
+           [
+             '%count' => count($users),
+           ]
+    );
+
     $userIdsToKeep = array_map(
         static function (array $user) use ($userIdClaim) {
           if (!isset($user[$userIdClaim])) {
@@ -164,7 +168,13 @@ class UserManager implements UserManagerInterface {
 
     $users = $this->userStorage->loadByProperties([$userIdField => $userIdsToKeep]);
     foreach ($users as $user) {
-      $this->logger->info($this->t('Retaining user @name.', ['@name' => $user->label()]));
+      $this->logger->info(
+        'Retaining user @name.',
+             [
+               '%name' => $user->label(),
+             ]
+      );
+
       unset($this->userIds[$user->id()]);
     }
   }
@@ -182,30 +192,45 @@ class UserManager implements UserManagerInterface {
       $deletedUserIds[] = $userId;
     }
 
-    $this->logger->info($this->formatPlural(
-      count($deletedUserIds),
-      'One user to be deleted',
-      '@count users to be deleted'
-    ));
+    $this->logger->info(
+      '@count users to be deleted',
+           [
+             '%count' => count($deletedUserIds),
+           ]
+    );
+
     if ($this->options['debug'] ?? FALSE) {
       $users = $this->userStorage->loadMultiple($deletedUserIds);
       if (empty($users)) {
-        $this->logger->debug(sprintf('No users to be deleted'));
+
+        $this->logger->info('No users to be deleted');
+
       }
       else {
         foreach ($users as $user) {
-          $this->logger->debug(sprintf('User to be deleted: %s (#%s)', $user->label(), $user->id()));
+
+          $this->logger->info(
+            'User to be deleted: %user (%id)',
+                 [
+                   '%user' => $user->label(),
+                   '%id' => $user->id(),
+                 ]
+          );
+
         }
       }
     }
 
     if (!($this->options['dry-run'] ?? FALSE)) {
       if (!empty($deletedUserIds)) {
-        $this->logger->info($this->formatPlural(
-          count($deletedUserIds),
-          'Deleting one user',
-          'Deleting @count users'
-        ));
+
+        $this->logger->info(
+          'Deleting @count user(s)',
+               [
+                 '%count' => count($deletedUserIds),
+               ]
+        );
+
         $this->requestStack->getCurrentRequest()
           // batch_process needs a route in the request (!)
           ->attributes->set(RouteObjectInterface::ROUTE_OBJECT, new Route('<none>'));

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -162,8 +162,6 @@ class UserManager implements UserManagerInterface {
         $users
       );
 
-    $this->logger->debug(json_encode($users, JSON_PRETTY_PRINT));
-
     $users = $this->userStorage->loadByProperties([$userIdField => $userIdsToKeep]);
     foreach ($users as $user) {
       $this->logger->info($this->t('Retaining user @name.', ['@name' => $user->label()]));
@@ -191,8 +189,12 @@ class UserManager implements UserManagerInterface {
     ));
     if ($this->options['debug'] ?? FALSE) {
       $users = $this->userStorage->loadMultiple($deletedUserIds);
-      foreach ($users as $user) {
-        $this->logger->debug(sprintf('User to be deleted: %s (#%s)', $user->label(), $user->id()));
+      if (empty($users)) {
+        $this->logger->debug(sprintf('No users to be deleted'));
+      } else {
+        foreach ($users as $user) {
+          $this->logger->debug(sprintf('User to be deleted: %s (#%s)', $user->label(), $user->id()));
+        }
       }
     }
 

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -227,9 +227,9 @@ class UserManager implements UserManagerInterface {
 
         $this->logger->info(
           'Deleting @count user(s)',
-               [
-                 '%count' => count($deletedUserIds),
-               ]
+          [
+            '%count' => count($deletedUserIds),
+          ]
         );
 
         $this->requestStack->getCurrentRequest()

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -191,7 +191,8 @@ class UserManager implements UserManagerInterface {
       $users = $this->userStorage->loadMultiple($deletedUserIds);
       if (empty($users)) {
         $this->logger->debug(sprintf('No users to be deleted'));
-      } else {
+      }
+      else {
         foreach ($users as $user) {
           $this->logger->debug(sprintf('User to be deleted: %s (#%s)', $user->label(), $user->id()));
         }

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -171,9 +171,9 @@ class UserManager implements UserManagerInterface {
       $this->logger->info(
         'Retaining user %user (%id)',
         [
-           '%user' => $user->label(),
-           '%id' => $user->id(),
-         ]
+          '%user' => $user->label(),
+          '%id' => $user->id(),
+        ]
       );
 
       unset($this->userIds[$user->id()]);

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -193,7 +193,7 @@ class UserManager implements UserManagerInterface {
     }
 
     $this->logger->info(
-      '@count users to be deleted',
+      '@count user(s) to be deleted',
            [
              '%count' => count($deletedUserIds),
            ]

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -169,10 +169,11 @@ class UserManager implements UserManagerInterface {
     $users = $this->userStorage->loadByProperties([$userIdField => $userIdsToKeep]);
     foreach ($users as $user) {
       $this->logger->info(
-        'Retaining user @name.',
-             [
-               '%name' => $user->label(),
-             ]
+        'Retaining user %user (%id)',
+        [
+           '%user' => $user->label(),
+           '%id' => $user->id(),
+         ]
       );
 
       unset($this->userIds[$user->id()]);

--- a/tests/src/Functional/UserManagerTest.php
+++ b/tests/src/Functional/UserManagerTest.php
@@ -147,11 +147,10 @@ class UserManagerTest extends BrowserTestBase {
 
     return new UserManager(
       $this->container->get('entity_type.manager'),
-      $configFactory,
       $this->container->get('database'),
       $this->container->get('request_stack'),
-      $this->container->get('module_handler'),
-      $logger
+      $logger,
+      $this->container->get('Drupal\azure_ad_delta_sync\Helpers\ConfigHelper'),
     );
   }
 

--- a/tests/src/Functional/UserManagerTest.php
+++ b/tests/src/Functional/UserManagerTest.php
@@ -150,7 +150,7 @@ class UserManagerTest extends BrowserTestBase {
       $this->container->get('database'),
       $this->container->get('request_stack'),
       $logger,
-      $this->container->get('Drupal\azure_ad_delta_sync\Helpers\ConfigHelper'),
+      $this->container->get(\Drupal\azure_ad_delta_sync\Helpers\ConfigHelper::class),
     );
   }
 

--- a/tests/src/Functional/UserManagerTest.php
+++ b/tests/src/Functional/UserManagerTest.php
@@ -20,7 +20,7 @@ class UserManagerTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected static $modules = ['azure_ad_delta_sync', 'drupal_psr6_cache'];
+  protected static $modules = ['azure_ad_delta_sync'];
 
   /**
    * {@inheritdoc}
@@ -146,7 +146,6 @@ class UserManagerTest extends BrowserTestBase {
     $logger = $this->createMock(LoggerInterface::class);
 
     return new UserManager(
-      $this->container->get('drupal_psr6_cache.cache_item_pool'),
       $this->container->get('entity_type.manager'),
       $configFactory,
       $this->container->get('database'),

--- a/tests/src/Functional/UserManagerTest.php
+++ b/tests/src/Functional/UserManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\azure_ad_delta_sync\Functional;
 
+use Drupal\azure_ad_delta_sync\Helpers\ConfigHelper;
 use Drupal\azure_ad_delta_sync\UserManager;
 use Drupal\azure_ad_delta_sync\UserManagerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -150,7 +151,7 @@ class UserManagerTest extends BrowserTestBase {
       $this->container->get('database'),
       $this->container->get('request_stack'),
       $logger,
-      $this->container->get(\Drupal\azure_ad_delta_sync\Helpers\ConfigHelper::class),
+      $this->container->get(ConfigHelper::class),
     );
   }
 


### PR DESCRIPTION
https://github.com/itk-dev/azure-ad-delta-sync-drupal/blob/825f644da9c8dca7b48a296f0a43b56800dfd002/azure_ad_delta_sync.services.yml#L7

- Changed `container->get` to match above
- Remove unused `drupal_psr6_cache` (removed between [`1.0.0`](https://github.com/itk-dev/azure-ad-delta-sync-drupal/blob/a874151f417d80afaab3d7056f787559f6bf5c94/composer.json#L15) and [`2.0.0`](https://github.com/itk-dev/azure-ad-delta-sync-drupal/blob/2.0.0/composer.json))
- Add test-command-runs to command, it just returns but fails if the command cannot run